### PR TITLE
Updated READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This project connects a Jupyter Notebook server running on either Linux on x86 o
 
 
 ## Install Jupyter Kernel Gateway and Apache Toree on z/OS
-To install the Jupyter Kernel Gateway to Apache Toree solution on z/OS, follow the [KG2AT instructions](zos/README.md).
+To install the Jupyter Kernel Gateway to Apache Toree solution on z/OS, follow the [KG2AT instructions](zos/).
 
 ## Install Jupyter Notebook server with nb2kg Extention
 To install a Jupyter Notebook server in a Docker container with nb2kg instructions on x86 follow the [nb2kg x86 instructions](x86/README.md).

--- a/zos/README.md
+++ b/zos/README.md
@@ -88,16 +88,14 @@ Builds a file, ```.kg2at_conf```, to be sourced for environmental setup.
 
 #### Parameters
 >Required
-> * -install_directory <DIR> or -i <DIR>
+> * `-install_directory <DIR>` or `-i <DIR>`
 >
->   <DIR> is the absolute path of directory where you’d like to extract
-    and install all tars.
+>   <DIR> is the absolute path of directory where you’d like to extract and install all tars.
 >
 >Optional
-> * -tar_directory <DIR> or -t <DIR>
+> * `-tar_directory <DIR>` or `-t <DIR>` 
 >
->   <DIR> is the absolute path of directory where your tar files are
-    located.
+>   <DIR> is the absolute path of directory where your tar files are located.
 
 #### Execution
 


### PR DESCRIPTION
Minor change to make the root README link to the zos landing page instead of the direct README file, so that it's easy to find and download the scripts.

Also changed the readme under zos to make the parameters section more readable. 